### PR TITLE
feat: developブランチでのIssue自動クローズ機能を追加

### DIFF
--- a/.github/workflows/auto-close-issues.yml
+++ b/.github/workflows/auto-close-issues.yml
@@ -1,0 +1,67 @@
+name: Auto Close Issues on PR Merge
+
+on:
+  pull_request:
+    types: [closed]
+    branches:
+      - develop
+      - main
+
+jobs:
+  close-issues:
+    if: github.event.pull_request.merged == true
+    runs-on: ubuntu-latest
+    
+    steps:
+    - name: Close linked issues
+      uses: actions/github-script@v7
+      with:
+        script: |
+          // PR本文からClosesキーワードを検索してIssue番号を抽出
+          const prBody = context.payload.pull_request.body || '';
+          const closeKeywords = ['closes', 'fixes', 'resolves'];
+          const issues = [];
+          
+          closeKeywords.forEach(keyword => {
+            const regex = new RegExp(`${keyword}\\s+#(\\d+)`, 'gi');
+            let match;
+            while ((match = regex.exec(prBody)) !== null) {
+              issues.push(parseInt(match[1]));
+            }
+          });
+          
+          // 重複を除去
+          const uniqueIssues = [...new Set(issues)];
+          
+          console.log(`Found issues to close: ${uniqueIssues}`);
+          
+          // 各Issueをクローズ
+          for (const issueNumber of uniqueIssues) {
+            try {
+              await github.rest.issues.update({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: issueNumber,
+                state: 'closed'
+              });
+              
+              // クローズコメントを追加
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: issueNumber,
+                body: `✅ Issue automatically closed by PR #${context.payload.pull_request.number}
+
+**Implementation completed:**
+- Branch: \`${context.payload.pull_request.head.ref}\`
+- Merged to: \`${context.payload.pull_request.base.ref}\`
+- Commit: ${context.payload.pull_request.merge_commit_sha}
+
+🤖 Auto-closed via GitHub Actions`
+              });
+              
+              console.log(`Successfully closed issue #${issueNumber}`);
+            } catch (error) {
+              console.error(`Failed to close issue #${issueNumber}:`, error);
+            }
+          }

--- a/package.json
+++ b/package.json
@@ -18,7 +18,8 @@
     "start-issue": "./scripts/start-issue.sh",
     "auto-issue": "./scripts/auto-issue.sh",
     "auto-implement": "node scripts/auto-implement.js",
-    "auto-cycle": "./scripts/auto-cycle.sh"
+    "auto-cycle": "./scripts/auto-cycle.sh",
+    "close-issues": "./scripts/close-linked-issues.sh"
   },
   "dependencies": {
     "@supabase/supabase-js": "^2.49.1",

--- a/scripts/close-linked-issues.sh
+++ b/scripts/close-linked-issues.sh
@@ -1,0 +1,45 @@
+#!/bin/bash
+
+# PR作成後にリンクされたIssueを自動クローズするスクリプト
+# Usage: ./scripts/close-linked-issues.sh "PR本文"
+
+set -e
+
+PR_BODY="$1"
+
+if [ -z "$PR_BODY" ]; then
+    echo "使用方法: $0 \"PR本文\""
+    exit 1
+fi
+
+echo "🔍 PR本文からIssue番号を検索中..."
+
+# Closes, Fixes, ResolvesキーワードからIssue番号を抽出
+ISSUE_NUMBERS=$(echo "$PR_BODY" | grep -iE "(closes?|fixes?|resolves?) #[0-9]+" | grep -oE "#[0-9]+" | sed 's/#//' | sort -u)
+
+if [ -z "$ISSUE_NUMBERS" ]; then
+    echo "📝 クローズ対象のIssueが見つかりませんでした"
+    exit 0
+fi
+
+echo "📋 発見されたIssue番号: $(echo $ISSUE_NUMBERS | tr '\n' ' ')"
+
+# 各Issueをクローズ
+for ISSUE_NUMBER in $ISSUE_NUMBERS; do
+    echo "🔒 Issue #$ISSUE_NUMBER をクローズ中..."
+    
+    if gh issue close "$ISSUE_NUMBER" --comment "✅ Issue自動クローズ実行
+
+**実装完了:**
+- PRでの実装により解決されました
+- ブランチ: $(git branch --show-current)
+- コミット: $(git rev-parse --short HEAD)
+
+🤖 Auto-closed by create-pr script"; then
+        echo "✅ Issue #$ISSUE_NUMBER を正常にクローズしました"
+    else
+        echo "❌ Issue #$ISSUE_NUMBER のクローズに失敗しました"
+    fi
+done
+
+echo "🎉 Issue自動クローズ処理が完了しました"

--- a/scripts/create-pr.sh
+++ b/scripts/create-pr.sh
@@ -114,3 +114,15 @@ echo "✅ プルリクエストが作成されました！"
 # 作成されたPRのURLを表示
 PR_URL=$(gh pr view --json url --jq .url)
 echo "PR URL: $PR_URL"
+
+# Issue自動クローズ処理（developブランチ向けPRの場合）
+if [ -n "$ISSUE_NUMBER" ]; then
+    echo ""
+    echo "🔒 Issue #$ISSUE_NUMBER の自動クローズを実行中..."
+    
+    if ./scripts/close-linked-issues.sh "$PR_BODY"; then
+        echo "✅ Issue自動クローズが完了しました"
+    else
+        echo "⚠️  Issue自動クローズでエラーが発生しました（手動でクローズしてください）"
+    fi
+fi


### PR DESCRIPTION
## 概要
developブランチへのPRマージ時にもIssue自動クローズが動作するように機能拡張

## 実装内容
- GitHub Actions ワークフロー追加（.github/workflows/auto-close-issues.yml）
  - developブランチへのPRマージ時に自動実行
  - PR本文からClosesキーワードを検出してIssue自動クローズ
- Issue自動クローズ専用スクリプト（scripts/close-linked-issues.sh）
  - PR本文からIssue番号を抽出
  - GitHub CLIでIssue自動クローズ + コメント追加
- create-pr.shスクリプトにIssue自動クローズ機能を統合
- npmコマンド追加: npm run close-issues

## 解決する問題
GitHubのデフォルト機能ではデフォルトブランチ（main）へのマージ時のみIssue自動クローズが動作するが、developブランチでも同様の機能を実現

## 使用方法
- 自動実行: PR作成・マージ時に自動でIssue自動クローズ
- 手動実行: npm run close-issues で個別実行も可能

## 技術的改善
- GitHub Actions + スクリプトの二重保証システム
- 既存ワークフローとの完全統合
- エラーハンドリングと詳細ログ出力

## 変更内容
- feat: developブランチでのIssue自動クローズ機能を追加

## テスト実行
- [ ] npm run type-check
- [ ] npm run lint
- [ ] npm run test:unit
- [ ] 動作確認

🤖 Generated with [Claude Code](https://claude.ai/code)