### PR TITLE
fix: DiaryViewPageの未使用変数を削除しESLintエラーを解消

### DIFF
--- a/src/views/DiaryViewPage.vue
+++ b/src/views/DiaryViewPage.vue
@@ -145,10 +145,8 @@ const {
   filter,
   pagination,
   changePage,
-  changePageSize,
   applyFilters,
   clearFilters,
-  moodStats,
   refresh,
 } = useDiaries({
   immediate: false, // 手動で初期化
@@ -211,11 +209,6 @@ const formatDate = (dateString: string): string => {
   return new Date(dateString).toLocaleDateString('ja-JP')
 }
 
-const getMoodColor = (mood: number): string => {
-  if (mood >= 4) return 'success'
-  if (mood >= 3) return 'warning'
-  return 'error'
-}
 
 // 日記詳細表示
 const viewDiary = (diary: DiaryEntry) => {
@@ -235,9 +228,6 @@ const handlePageChange = (page: number) => {
   changePage(page)
 }
 
-const handlePageSizeChange = (pageSize: number) => {
-  changePageSize(pageSize)
-}
 
 // フィルター適用処理
 const handleApplyFilters = () => {


### PR DESCRIPTION
## Summary
DiaryViewPage.vueで発生していた未使用変数のESLintエラー3つを解消し、コード品質を向上

## Root Cause Analysis (根本原因分析)
**なぜこの問題が発生したか:**
- [x] 実装時のロジックミス
- [ ] 設計段階での考慮不足  
- [ ] テストケースの不備
- [ ] 外部依存関係の変更
- [ ] 要件の理解不足
- [ ] 技術選定の問題
- [ ] その他: [具体的な原因を記述]

**具体的な原因:**
機能開発過程で以下の変数が定義されたが、実際のUI実装では使用されずに残された状態

**今後の予防策:**
- コミット前のESLintエラーチェック徹底
- 未使用変数の定期的な見直し

## 修正内容
- ❌ `moodStats`: useDiariesから取得していた未使用の気分統計データ
- ❌ `getMoodColor`: 気分値に応じた色を返す未使用関数
- ❌ `handlePageSizeChange`: ページサイズ変更の未使用ハンドラー
- ❌ `changePageSize`: 依存関係で不要になった変数

## Test plan
- [x] ESLintエラー解消確認 (`npm run ci:lint`)
- [x] 既存機能への影響なし確認
- [x] 型チェック通過確認

Closes #141

🤖 Generated with [Claude Code](https://claude.ai/code)