### PR TITLE
perf(core): Automated performance tuning by Claude

### DIFF
--- a/src/features/reports/composables/useWeeklyAnalysis.ts
+++ b/src/features/reports/composables/useWeeklyAnalysis.ts
@@ -153,27 +153,27 @@ export function useWeeklyAnalysis() {
     weekRange: ReturnType<typeof getWeekRange>,
   ): WeeklyMoodData[] => {
     const moodData: WeeklyMoodData[] = []
+    const moodByDate: Record<string, { sum: number; count: number }> = {}
+
+    diaries.forEach((diary) => {
+      const dateKey = new Date(diary.created_at).toISOString().split('T')[0]
+      if (!moodByDate[dateKey]) {
+        moodByDate[dateKey] = { sum: 0, count: 0 }
+      }
+      moodByDate[dateKey].sum += diary.mood || 5
+      moodByDate[dateKey].count++
+    })
 
     // 1週間の各日について処理
     for (let i = 0; i < 7; i++) {
       const date = new Date(weekRange.start)
       date.setDate(weekRange.start.getDate() + i)
       const dateString = date.toISOString().split('T')[0]
-
-      // その日の日記を検索
-      const dayDiaries = diaries.filter((diary) => {
-        const diaryDate = new Date(diary.created_at).toISOString().split('T')[0]
-        return diaryDate === dateString
-      })
+      const dayMood = moodByDate[dateString]
 
       // その日の平均気分スコアを計算
       const averageMood =
-        dayDiaries.length > 0
-          ? Math.round(
-              (dayDiaries.reduce((sum, diary) => sum + (diary.mood || 5), 0) / dayDiaries.length) *
-                10,
-            ) / 10
-          : 0
+        dayMood && dayMood.count > 0 ? Math.round((dayMood.sum / dayMood.count) * 10) / 10 : 0
 
       moodData.push({
         date: dateString,


### PR DESCRIPTION
### Motivation

- 週間分析で週毎の気分平均を算出する処理が大量データ時に非効率（同一配列を日毎に `filter` + `reduce` で繰り返す）だったため、処理時間を短縮して応答性を改善する目的で修正しました。
- 機能的な振る舞いは維持しつつ、実行速度の改善（実行全体の2%以上）を目標としています。

### Description

- 対象ファイルは `src/features/reports/composables/useWeeklyAnalysis.ts` の `createWeeklyMoodData` 関数で、日毎に `filter`/`reduce` を繰り返す実装を1回走査して日付ごとの `sum/count` マップを構築する方式に置き換えました。 
- アルゴリズムの計算量を O(7*n) から O(n + 7) に削減し、ループ内はマップ参照のみで平均値を算出するように変更しました。 
- 外部インターフェース・返却データ構造・UI挙動には変更を加えていません。

### Testing

- ベンチマーク（Node.js v20、日記50,000件、100反復）で旧実装 `1041.12ms` → 新実装 `532.32ms`、改善率 `48.87%` で、改善指標（実行全体の2%以上）を満たしました。 
- ユニットテストは `npm run test:unit -- tests/unit/features/reports/normal_useWeeklyAnalysis_01.spec.js` を実行して対象テスト（12件）が全てパスしました。 
- `npx eslint src/features/reports/composables/useWeeklyAnalysis.ts --config config/eslint.config.js` による静的解析は該当ファイルでパスしました。

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fb3c774b3c832891bbe62d6933b006)